### PR TITLE
修复压缩中断重新压缩时的报错

### DIFF
--- a/Sources/KSAssetExportSession.swift
+++ b/Sources/KSAssetExportSession.swift
@@ -346,6 +346,7 @@ extension AVAsset {
         videoOutput.alwaysCopiesSampleData = false
         videoOutput.videoComposition = makeVideoComposition(videoOutputConfiguration: videoOutputConfiguration)
         exporter.videoOutput = videoOutput
+        try? FileManager.default.removeItem(at: outputURL)
         do {
             try exporter.export(progressHandler: progressHandler, completionHandler: completionHandler)
         } catch let error as NSError? {
@@ -372,6 +373,7 @@ extension AVAsset {
         exporter.metadata = [AVMutableMetadataItem(assetIdentifier: assetIdentifier)]
         exporter.writerInput = [AVAssetWriterInput.makeMetadataAdapter()]
         exporter.synchronous = true
+        try? FileManager.default.removeItem(at: outputURL)
         do {
             try exporter.export(progressHandler: nil, completionHandler: completionHandler)
         } catch let error as NSError? {
@@ -445,9 +447,9 @@ extension AVAssetWriterInput {
     fileprivate static func makeMetadataAdapter() -> AVAssetWriterInput {
         let spec = [
             kCMMetadataFormatDescriptionMetadataSpecificationKey_Identifier:
-                "mdta/com.apple.quicktime.still-image-time",
+            "mdta/com.apple.quicktime.still-image-time",
             kCMMetadataFormatDescriptionMetadataSpecificationKey_DataType:
-                "com.apple.metadata.datatype.int8",
+            "com.apple.metadata.datatype.int8",
         ]
         var desc: CMFormatDescription?
         CMMetadataFormatDescriptionCreateWithMetadataSpecifications(allocator: kCFAllocatorDefault, metadataType: kCMMetadataFormatType_Boxed, metadataSpecifications: [spec] as CFArray, formatDescriptionOut: &desc)


### PR DESCRIPTION
压缩过程中中断了，此时重新压缩会导致报错，这里删除掉之前压缩遗留的占位文件